### PR TITLE
created grant_read macro for on-run-end hooks

### DIFF
--- a/macros/hook_functions/on_run_end_grant_rights.sql
+++ b/macros/hook_functions/on_run_end_grant_rights.sql
@@ -1,0 +1,38 @@
+{%- macro grant_read(users=none, schemas_list=none, include_main_schema=true) -%}
+
+  {% for user in users %}
+
+    {% if schemas_list %}
+
+      {% if include_main_schema %}
+
+        {% do schemas_list.append(target.schema) %}
+
+      {% endif %}
+
+      {% for schema in schemas_list %}
+
+          grant usage on schema {{ schema }} to {{ user }};
+          grant select on all tables in schema {{ schema }} to {{ user }};
+
+      {% endfor %}
+
+    {% else %}
+
+      {% for schema in schemas %}
+
+        {% if include_main_schema or
+              (include_main_schema == false and schema != target.schema) %}
+
+          grant usage on schema {{ schema }} to {{ user }};
+          grant select on all tables in schema {{ schema }} to {{ user }};
+
+        {% endif %}
+
+      {% endfor %}
+
+    {% endif %}
+
+  {% endfor %}
+
+{%- endmacro -%}


### PR DESCRIPTION
Created grant_read macro for on_run_end hooks. variables are:
- users (expects a list even if its only one element)
- schemas_list (schemas is a reserved dbt keyword for post-hooks/on-run-end hooks. leaving it empty will grant read rights to all run schemas)
- include_main_schema (true/false)