### PR TITLE
On run start create functions

### DIFF
--- a/macros/hook_functions/create_postgres_funcs.sql
+++ b/macros/hook_functions/create_postgres_funcs.sql
@@ -1,20 +1,26 @@
-{% macro create_funcs(field_type_list=none, func_name_list=none) %}
+{% macro create_funcs(field_type_list, func_name_list=none) %}
 
   {% set type_list_len = field_type_list|length %}
 
-  {% set name_list_len = func_name_list|length %}
+  {% set name_list_len = func_name_list|length if func_name_list is not none else 0 %}
 
-  {% if name_list_len != type_list_len %}
+  {% if func_name_list and name_list_len != type_list_len %}
 
     {{ exceptions.raise_compiler_error("Error: Name and type list dont have the same length.") }}
 
   {% endif %}
 
-  {{ log("geschafft", info=True) }}
+  {% for i in range(0, type_list_len) %}
 
-  {% for i in range(0, name_list_len) %}
+    {% if func_name_list %}
 
-      {{ create_func_is_type(field_type[i], func_name[i]) }}
+      {{ gemma_dbt_utils.create_func_is_type(field_type_list[i], func_name_list[i] )}}
+
+    {% else %}
+
+      {{ gemma_dbt_utils.create_func_is_type(field_type_list[i]) }}
+
+    {% endif %}
 
   {% endfor %}
 

--- a/macros/hook_functions/create_postgres_funcs.sql
+++ b/macros/hook_functions/create_postgres_funcs.sql
@@ -1,0 +1,46 @@
+{% macro create_funcs(field_type_list=none, func_name_list=none) %}
+
+  {% set type_list_len = field_type_list|length %}
+
+  {% set name_list_len = func_name_list|length %}
+
+  {% if name_list_len != type_list_len %}
+
+    {{ exceptions.raise_compiler_error("Error: Name and type list dont have the same length.") }}
+
+  {% endif %}
+
+  {{ log("geschafft", info=True) }}
+
+  {% for i in range(0, name_list_len) %}
+
+      {{ create_func_is_type(field_type[i], func_name[i]) }}
+
+  {% endfor %}
+
+{% endmacro %}
+
+-------------------------------------------------------------------------------
+
+{% macro create_func_is_type(field_type, func_name=none) %}
+
+  {% if not func_name %}
+
+    {% set func_name = 'gemma_is_' ~ field_type.lower() %}
+
+  {% endif %}
+  -- Adapted from
+  -- https://stackoverflow.com/questions/16195986/isnumeric-with-postgresql
+  CREATE OR REPLACE FUNCTION {{ func_name }}(text) RETURNS BOOLEAN AS $$
+  DECLARE x {{ field_type }};
+  BEGIN
+    x = $1::{{ field_type }};
+    RETURN TRUE;
+  EXCEPTION WHEN others THEN
+    RETURN FALSE;
+  END;
+  $$
+  STRICT
+  LANGUAGE plpgsql IMMUTABLE;
+
+{% endmacro %}


### PR DESCRIPTION
Created on-run-start hook macro for creating Postgres "is_type_x" functions that take strings as an arg:

- create_funcs(field_type_list, func_name_list=none)
- create_func_is_type(field_type, func_name=none)

 Args are:

- field_type_list (mandatory, list with all types you want to create a function with)
- func_name_list (optional, if provided, the length should be the same as field_type_list in the same order you want to call the functions)
- func_name (optional, create_func_is_type is only for single functions)