### PR TITLE
Add year_quarter column to Postgres & BigQuery adapters

### DIFF
--- a/models/gemma_dates.sql
+++ b/models/gemma_dates.sql
@@ -65,6 +65,7 @@
         AS next_month_first_day
       , DATE(DATE_TRUNC('month', date) + INTERVAL '2 month - 1 day')
         AS next_month_last_day
+      , EXTRACT(YEAR FROM date) || '-Q' || EXTRACT(QUARTER FROM date) AS year_quarter
 
     FROM dates
 
@@ -122,6 +123,7 @@
       , DATE_TRUNC(DATE_ADD(date, INTERVAL 1 MONTH), MONTH)
         AS next_month_first_day
       , LAST_DAY(DATE_ADD(date, INTERVAL 1 MONTH), MONTH) AS next_month_last_day
+      , EXTRACT(YEAR FROM date) || '-Q' || EXTRACT(QUARTER FROM date) AS year_quarter
 
   FROM dates
 

--- a/models/gemma_dates.sql
+++ b/models/gemma_dates.sql
@@ -123,7 +123,7 @@
       , DATE_TRUNC(DATE_ADD(date, INTERVAL 1 MONTH), MONTH)
         AS next_month_first_day
       , LAST_DAY(DATE_ADD(date, INTERVAL 1 MONTH), MONTH) AS next_month_last_day
-      , EXTRACT(YEAR FROM date) || '-Q' || EXTRACT(QUARTER FROM date) AS year_quarter
+      , EXTRACT(YEAR FROM date) || '-Q' || FORMAT_DATE('%Q', date) AS year_quarter
 
   FROM dates
 


### PR DESCRIPTION
Is there a chance that this would not work for Big Query? 

I can't see the same concatenation "|| '-Q' ||" format used in any other BigQuery column in the model: but this article says it should work https://count.co/sql-resources/bigquery-standard-sql/concat