### PR TITLE
Add auto-incrementing Week ID to Gemma Dates model

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 
 name: 'gemma_dbt_utils'
-version: '0.4.5'
+version: '0.4.6'
 
 require-dbt-version: ">=1.0.0"
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 
 name: 'gemma_dbt_utils'
-version: '0.4.6'
+version: '0.4.7'
 
 require-dbt-version: ">=1.0.0"
 

--- a/models/gemma_dates.sql
+++ b/models/gemma_dates.sql
@@ -66,6 +66,12 @@
       , DATE(DATE_TRUNC('month', date) + INTERVAL '2 month - 1 day')
         AS next_month_last_day
       , EXTRACT(YEAR FROM date) || '-Q' || EXTRACT(QUARTER FROM date) AS year_quarter
+      , DENSE_RANK() OVER
+        (ORDER BY
+          EXTRACT(ISOYEAR FROM date) ||
+          TO_CHAR(date, '"-CW"IW') ASC
+        )
+        AS week_id
 
     FROM dates
 
@@ -124,6 +130,12 @@
         AS next_month_first_day
       , LAST_DAY(DATE_ADD(date, INTERVAL 1 MONTH), MONTH) AS next_month_last_day
       , EXTRACT(YEAR FROM date) || '-Q' || FORMAT_DATE('%Q', date) AS year_quarter
+      , DENSE_RANK() OVER
+        (ORDER BY
+          CAST(EXTRACT(ISOYEAR FROM date) AS STRING) ||
+          CAST(EXTRACT(WEEK FROM date) AS STRING) ASC
+        )
+        AS week_id
 
   FROM dates
 
@@ -222,6 +234,12 @@
       , DATE(DATE_TRUNC('month', date) + INTERVAL '2 month' - INTERVAL '1 day')
         AS next_month_last_day
       , EXTRACT(YEAR FROM date) || '-Q' || EXTRACT(QUARTER FROM date) AS year_quarter
+      , DENSE_RANK() OVER
+        (ORDER BY
+          EXTRACT(ISOYEAR FROM date)::TEXT ||
+          EXTRACT(WEEK FROM date)::TEXT ASC
+        )
+          AS week_id
 
     FROM dates
 

--- a/models/gemma_dates.sql
+++ b/models/gemma_dates.sql
@@ -66,10 +66,8 @@
       , DATE(DATE_TRUNC('month', date) + INTERVAL '2 month - 1 day')
         AS next_month_last_day
       , EXTRACT(YEAR FROM date) || '-Q' || EXTRACT(QUARTER FROM date) AS year_quarter
-      , DENSE_RANK() OVER
-        (ORDER BY
-          EXTRACT(ISOYEAR FROM date) ASC,
-          EXTRACT(WEEK FROM date) ASC
+      , DENSE_RANK() OVER (
+          ORDER BY EXTRACT(ISOYEAR FROM date) ASC, EXTRACT(WEEK FROM date) ASC
         )
         AS week_id
 

--- a/models/gemma_dates.sql
+++ b/models/gemma_dates.sql
@@ -128,9 +128,8 @@
         AS next_month_first_day
       , LAST_DAY(DATE_ADD(date, INTERVAL 1 MONTH), MONTH) AS next_month_last_day
       , EXTRACT(YEAR FROM date) || '-Q' || FORMAT_DATE('%Q', date) AS year_quarter
-      , DENSE_RANK() OVER
-        (ORDER BY
-          EXTRACT(ISOYEAR FROM DATE) ASC, EXTRACT(WEEK FROM DATE) ASC
+      , DENSE_RANK() OVER (
+          ORDER BY EXTRACT(ISOYEAR FROM DATE) ASC, EXTRACT(WEEK FROM DATE) ASC
         )
         AS week_id
 
@@ -231,9 +230,8 @@
       , DATE(DATE_TRUNC('month', date) + INTERVAL '2 month' - INTERVAL '1 day')
         AS next_month_last_day
       , EXTRACT(YEAR FROM date) || '-Q' || EXTRACT(QUARTER FROM date) AS year_quarter
-      , DENSE_RANK() OVER
-        (ORDER BY
-          EXTRACT(ISOYEAR FROM date) ASC, EXTRACT(WEEK FROM date) ASC
+      , DENSE_RANK() OVER (
+          ORDER BY EXTRACT(ISOYEAR FROM date) ASC, EXTRACT(WEEK FROM date) ASC
         )
         AS week_id
 

--- a/models/gemma_dates.sql
+++ b/models/gemma_dates.sql
@@ -68,8 +68,8 @@
       , EXTRACT(YEAR FROM date) || '-Q' || EXTRACT(QUARTER FROM date) AS year_quarter
       , DENSE_RANK() OVER
         (ORDER BY
-          EXTRACT(ISOYEAR FROM date) ||
-          TO_CHAR(date, '"-CW"IW') ASC
+          EXTRACT(ISOYEAR FROM date) ASC,
+          EXTRACT(WEEK FROM date) ASC
         )
         AS week_id
 
@@ -132,8 +132,8 @@
       , EXTRACT(YEAR FROM date) || '-Q' || FORMAT_DATE('%Q', date) AS year_quarter
       , DENSE_RANK() OVER
         (ORDER BY
-          CAST(EXTRACT(ISOYEAR FROM date) AS STRING) ||
-          CAST(EXTRACT(WEEK FROM date) AS STRING) ASC
+          EXTRACT(ISOYEAR FROM DATE) ASC,
+          EXTRACT(WEEK FROM DATE) ASC
         )
         AS week_id
 
@@ -236,10 +236,10 @@
       , EXTRACT(YEAR FROM date) || '-Q' || EXTRACT(QUARTER FROM date) AS year_quarter
       , DENSE_RANK() OVER
         (ORDER BY
-          EXTRACT(ISOYEAR FROM date)::TEXT ||
-          EXTRACT(WEEK FROM date)::TEXT ASC
+          EXTRACT(ISOYEAR FROM date) ASC,
+          EXTRACT(WEEK FROM date) ASC
         )
-          AS week_id
+        AS week_id
 
     FROM dates
 

--- a/models/gemma_dates.sql
+++ b/models/gemma_dates.sql
@@ -130,8 +130,7 @@
       , EXTRACT(YEAR FROM date) || '-Q' || FORMAT_DATE('%Q', date) AS year_quarter
       , DENSE_RANK() OVER
         (ORDER BY
-          EXTRACT(ISOYEAR FROM DATE) ASC,
-          EXTRACT(WEEK FROM DATE) ASC
+          EXTRACT(ISOYEAR FROM DATE) ASC, EXTRACT(WEEK FROM DATE) ASC
         )
         AS week_id
 
@@ -234,8 +233,7 @@
       , EXTRACT(YEAR FROM date) || '-Q' || EXTRACT(QUARTER FROM date) AS year_quarter
       , DENSE_RANK() OVER
         (ORDER BY
-          EXTRACT(ISOYEAR FROM date) ASC,
-          EXTRACT(WEEK FROM date) ASC
+          EXTRACT(ISOYEAR FROM date) ASC, EXTRACT(WEEK FROM date) ASC
         )
         AS week_id
 


### PR DESCRIPTION
### Description & motivation
I would like an auto-incrementing 'week ID' field - so that when doing week over week comparisons, [week_id] - 1 will always give the previous week, and we do not have to worry about the week number changing from week 52 to week 1.
